### PR TITLE
Fix journal entry lookup logic

### DIFF
--- a/src/main/java/com/manideep/journalApp/controllers/JournalController.java
+++ b/src/main/java/com/manideep/journalApp/controllers/JournalController.java
@@ -51,7 +51,7 @@ public class JournalController {
     }
 
     @DeleteMapping("id/{userId}/journalId/{journalId}")
-    public ResponseEntity<?> deleteJournalEntryById(@PathVariable ObjectId journalId){
+    public ResponseEntity<?> deleteJournalEntryById(@PathVariable ObjectId userId, @PathVariable ObjectId journalId){
         try{
             journalEntryService.deleteById(journalId);
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -63,7 +63,7 @@ public class JournalController {
 
     @PutMapping("id/{userId}/journalId/{journalId}")
     public ResponseEntity<JournalEntry> updateJournalEntry(@PathVariable ObjectId journalId,@PathVariable ObjectId userId,@RequestBody JournalEntry newJournalEntry){
-        JournalEntry journalEntry = journalEntryService.findById(journalId,userId);
+        JournalEntry journalEntry = journalEntryService.findById(userId, journalId);
         if(journalEntry != null){
             return new ResponseEntity<>(journalEntryService.updateById(journalId,newJournalEntry,journalEntry),HttpStatus.OK);
         }

--- a/src/main/java/com/manideep/journalApp/services/JournalEntryService.java
+++ b/src/main/java/com/manideep/journalApp/services/JournalEntryService.java
@@ -43,7 +43,9 @@ public class JournalEntryService {
         if(user != null){
             JournalEntry journalEntry = user.getJournalEntries()
                                         .stream()
-                                        .filter(x -> x.getId() == journalId).findFirst().orElse(null);
+                                        .filter(x -> journalId.equals(x.getId()))
+                                        .findFirst()
+                                        .orElse(null);
             if(journalEntry != null){
                 return journalEntry;
             }


### PR DESCRIPTION
## Summary
- fix ObjectId equality check when finding journal entries
- correct parameter order for `findById` in the journal controller
- bind `userId` path variable in delete endpoint

## Testing
- `sh ./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68467b158f7c8333b4f456579efb5795