### PR TITLE
Add simple frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Journal Application</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+    <h1 class="title">Journal Application</h1>
+    <div id="auth-section" class="card">
+        <h2>Login</h2>
+        <input type="text" id="login-name" placeholder="Username" />
+        <input type="password" id="login-password" placeholder="Password" />
+        <button id="login-btn">Login</button>
+
+        <h3>or Sign Up</h3>
+        <input type="text" id="signup-name" placeholder="Username" />
+        <input type="password" id="signup-password" placeholder="Password" />
+        <button id="signup-btn">Create Account</button>
+    </div>
+
+    <div id="journal-section" class="card hidden">
+        <h2>New Journal Entry</h2>
+        <input type="text" id="entry-title" placeholder="Title" />
+        <textarea id="entry-content" placeholder="Write something..."></textarea>
+        <button id="add-entry-btn">Save Entry</button>
+
+        <h2>Your Entries</h2>
+        <div id="entries"></div>
+    </div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,75 @@
+let authToken = '';
+
+async function signup() {
+    const name = document.getElementById('signup-name').value;
+    const password = document.getElementById('signup-password').value;
+
+    const res = await fetch('/public/createUser', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password })
+    });
+    if (res.ok) {
+        alert('User created! You can log in now.');
+    } else {
+        alert('Failed to create user');
+    }
+}
+
+function getAuthHeader() {
+    const user = document.getElementById('login-name').value;
+    const pass = document.getElementById('login-password').value;
+    return 'Basic ' + btoa(user + ':' + pass);
+}
+
+async function login() {
+    authToken = getAuthHeader();
+    const res = await fetch('/journal/getAllJournals', {
+        headers: { 'Authorization': authToken }
+    });
+    if (res.ok) {
+        document.getElementById('auth-section').classList.add('hidden');
+        document.getElementById('journal-section').classList.remove('hidden');
+        const data = await res.json();
+        renderEntries(data);
+    } else {
+        alert('Login failed');
+    }
+}
+
+async function addEntry() {
+    const title = document.getElementById('entry-title').value;
+    const content = document.getElementById('entry-content').value;
+
+    const res = await fetch('/journal/createJournal', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': authToken
+        },
+        body: JSON.stringify({ title, content })
+    });
+    if (res.ok) {
+        const entry = await res.json();
+        renderEntries([entry], true);
+        document.getElementById('entry-title').value = '';
+        document.getElementById('entry-content').value = '';
+    } else {
+        alert('Failed to save entry');
+    }
+}
+
+function renderEntries(entries, append = false) {
+    const container = document.getElementById('entries');
+    if (!append) container.innerHTML = '';
+    entries.forEach(e => {
+        const div = document.createElement('div');
+        div.className = 'entry';
+        div.innerHTML = `<h4>${e.title}</h4><p>${e.content}</p><small>${e.date}</small>`;
+        container.prepend(div);
+    });
+}
+
+document.getElementById('signup-btn').addEventListener('click', signup);
+document.getElementById('login-btn').addEventListener('click', login);
+document.getElementById('add-entry-btn').addEventListener('click', addEntry);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,78 @@
+body {
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(135deg, #74ebd5, #9face6);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    height: 100vh;
+    align-items: center;
+    justify-content: center;
+}
+
+.container {
+    width: 90%;
+    max-width: 600px;
+}
+
+.title {
+    text-align: center;
+    color: #fff;
+    margin-bottom: 20px;
+}
+
+.card {
+    background: #ffffffbb;
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+}
+
+.card input,
+.card textarea {
+    width: 100%;
+    padding: 10px;
+    margin-top: 10px;
+    border: none;
+    border-radius: 6px;
+    box-sizing: border-box;
+}
+
+.card button {
+    width: 100%;
+    padding: 10px;
+    margin-top: 10px;
+    border: none;
+    color: #fff;
+    background: #3f51b5;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+.card button:hover {
+    background: #283593;
+}
+
+.hidden {
+    display: none;
+}
+
+#entries {
+    margin-top: 20px;
+}
+
+.entry {
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 10px;
+    margin-bottom: 10px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- add a minimal HTML/CSS/JS frontend
- provide login and signup UI
- allow creating journal entries and listing them with simple animations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68467c5bbd788333918bd86086af5293